### PR TITLE
Write symlinks in live directory rather than files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ var path = require('path');
 var fs = PromiseA.promisifyAll(require('fs'));
 var sfs = require('safe-replace');
 var os = require('os');
+var symlink = require('fs-symlink');
 
 function log(debug) {
   if (debug) {
@@ -267,10 +268,10 @@ module.exports.create = function (configs) {
             return mkdirpAsync(liveDir);
           }).then(function () {
             return PromiseA.all([
-              sfs.writeFileAsync(certPath, pems.cert, 'ascii')
-            , sfs.writeFileAsync(chainPath, pems.chain, 'ascii')
-            , sfs.writeFileAsync(fullchainPath, pems.cert + pems.chain, 'ascii')
-            , sfs.writeFileAsync(privkeyPath, pems.privkey, 'ascii')
+              symlink(certArchive, certPath)
+            , symlink(chainArchive, chainPath)
+            , symlink(fullchainArchive, fullchainPath)
+            , symlink(privkeyArchive, privkeyPath)
             ]);
           }).then(function () {
             pyobj.checkpoints += 1;

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "homepage": "https://git.daplie.com/Daplie/le-store-certbot#readme",
   "dependencies": {
     "bluebird": "^3.4.1",
+    "fs-symlink": "^1.2.1",
     "mkdirp": "^0.5.1",
     "pyconf": "^1.1.2",
     "safe-replace": "^1.0.2"


### PR DESCRIPTION
The `certbot` CLI tool requires these to be symlinks to the archive directory and will not function properly otherwise.